### PR TITLE
change version check to "version"

### DIFF
--- a/docs/wipy/general.rst
+++ b/docs/wipy/general.rst
@@ -110,7 +110,7 @@ read the **release notes** before.
 In order to check your software version, do::
 
    >>> import os
-   >>> os.uname().release
+   >>> os.uname().version
 
 If the version number is lower than the latest release found in
 `the releases <https://github.com/wipy/wipy/releases>`_, go ahead and update your WiPy!


### PR DESCRIPTION
The "release" is way beyond the "version" and checking for it confuses esp. new users. The referred site https://github.com/wipy/wipy/releases uses the "version" too.